### PR TITLE
Support additional flags; env-file and dir mappings

### DIFF
--- a/tools/c2wnet/c2wnet.go
+++ b/tools/c2wnet/c2wnet.go
@@ -23,8 +23,12 @@ const (
 )
 
 func main() {
-	var portFlags sliceFlags
+	var (
+		portFlags   sliceFlags
+		volumeFlags sliceFlags
+	)
 	flag.Var(&portFlags, "p", "map port between host and guest (host:guest). -mac must be set correctly.")
+	flag.Var(&volumeFlags, "v", "map directory between host and guest (host_dir::guest_dir or host_dir)")
 	var (
 		debug    = flag.Bool("debug", false, "enable debug print")
 		listenWS = flag.Bool("listen-ws", false, "listen on a websocket port specified as argument")
@@ -53,6 +57,7 @@ func main() {
 	}
 	if *debug {
 		fmt.Fprintf(os.Stderr, "port mapping: %+v\n", forwards)
+		fmt.Fprintf(os.Stderr, "volume mapping: %+v\n", volumeFlags)
 	}
 	config := &gvntypes.Configuration{
 		Debug:             *debug,
@@ -99,6 +104,11 @@ func main() {
 		// Add env-file parameter if provided
 		if *envFile != "" {
 			cmdArgs = append(cmdArgs, "--env-file="+*envFile)
+		}
+		// Add volume mounts
+		for _, volume := range volumeFlags {
+			// The volume string can be either "host_dir" or "host_dir::guest_dir"
+			cmdArgs = append(cmdArgs, "--dir="+volume)
 		}
 		// Append the remaining arguments
 		cmdArgs = append(cmdArgs, "--")


### PR DESCRIPTION
# Features
- Adds support for `--env-file` CLI flag to specify the path to an environment file
- Adds support for `-v` CLI flag to map directories between host and guest

Example:
```sh
go run tools/c2wnet/*.go --debug --invoke -p 4240:4240 -p 4241:4241 -p 4242:4242 -p 4243:4243 --env-file .env  -v /tmp/::/tmp/ ./server.wasm --net=socket
```